### PR TITLE
Patch for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ for more information on how to install LTSpice.
 
 ### Python Dependencies
 To install the required python libraries and setup the project on Windows run: \
-```python.exe -m pip install --upgrade pip``` \
+```python.exe -m pip install --upgrade pip``` or ```python3 -m pip install --upgrade pip``` \
 ```python -m venv .venv``` \
-```.\venv\Scripts\activate.bat``` or ```.\venv\Scripts\activate.ps1 ``` \
+```.\venv\Scripts\activate.bat``` or ```.\venv\Scripts\activate.ps1 ``` or ```source .venv/bin/activate (Mac)```\
 ```pip install -r requirements.txt``` 
 
 ## How to use

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ for more information on how to install LTSpice.
 ### Python Dependencies
 To install the required python libraries and setup the project on Windows run: \
 ```python.exe -m pip install --upgrade pip``` or ```python3 -m pip install --upgrade pip``` \
-```python -m venv .venv``` \
+```python -m venv .venv``` or ```python3 -m venv .venv``` \
 ```.\venv\Scripts\activate.bat``` or ```.\venv\Scripts\activate.ps1 ``` or ```source .venv/bin/activate (Mac)```\
 ```pip install -r requirements.txt``` 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scipy==1.13.0
 PyLTSpice==5.3.1
 spicelib==1.1.2
 tqdm==4.66.4
+ipykernel==6.30.1

--- a/src/util.py
+++ b/src/util.py
@@ -10,6 +10,8 @@ import csv
 import re
 import os
 import shutil
+import sys 
+import string
 
 number_suffixes = ["a", "f", "p", "n", "u", "m", "", "k", "M", "G", "T", "P", "E"] 
 
@@ -39,13 +41,21 @@ def extract_energy_from_log(file_path: str) -> float | None:
 
     # Open the file and read line by line
     with open(file_path, 'r') as file:
-        for line in file:
-            match = pattern.search(line)
-            if match:
+        if sys.platform == 'darwin': 
+            for raw_line in file:
+                line = ''.join(c for c in raw_line if c in string.printable) 
+                match = pattern.search(line)
                 # Extract the number after "="
-                number = match.group(1)
-                return number
-
+                if match:
+                    number = match.group(1)
+                    return number
+        else: 
+            for line in file:
+                match = pattern.search(line)
+                if match:
+                    # Extract the number after "="
+                    number = match.group(1)
+                    return number
     return None
 
 


### PR DESCRIPTION
Simulator.py:
Added if-clause for netlist extraction to constructor sourcing local netlist instead of calling LTSpice due to no native LTSpice console support on Mac. Require locally stored netlists in Structures/*/ 

util.py:
Added special character parsing to extract_energy_from_log() due to occuring different encoding in Mac-Type logs 

requirements.txt
Added ipykernel for native jupyter notebook support on Virtual Studio Code

README.md
Added installation support command to Pytho Dependencies section